### PR TITLE
feat: 行動グラフと感情グラフの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ WatchMeプラットフォームのiOSアプリケーション（バージョン9
 
 ### 分析・レポート機能
 - **心理グラフ (Vibe Graph)**: 日々の感情スコア、ポジティブ/ネガティブの時間分布、AIインサイトを表示
-- **行動グラフ (Behavior Graph)**: 行動パターンの分析（Coming Soon）
-- **感情グラフ (Emotion Graph)**: 感情の変化を詳細に分析（Coming Soon）
+- **行動グラフ (Behavior Graph)**: 1日の行動パターンをランキングと時間帯別で可視化（v9.10.0〜）
+- **感情グラフ (Emotion Graph)**: 8つの感情（Joy、Fear、Anger、Trust、Disgust、Sadness、Surprise、Anticipation）の時系列変化を折れ線グラフで表示（v9.10.0〜）
 
 ### ユーザー・デバイス管理
 - **Supabase認証**: メールアドレスとパスワードによる安全な認証
@@ -175,8 +175,8 @@ ios_watchme_v9/
 ├── Views/
 │   ├── HomeView.swift         # 心理グラフ（Vibe Graph）表示
 │   ├── RecordingView.swift    # 録音機能とファイル管理
-│   ├── BehaviorGraphView.swift # 行動グラフ（Coming Soon）
-│   ├── EmotionGraphView.swift  # 感情グラフ（Coming Soon）
+│   ├── BehaviorGraphView.swift # 行動グラフ
+│   ├── EmotionGraphView.swift  # 感情グラフ
 │   ├── LoginView.swift         # ログインUI
 │   └── ReportTestView.swift    # デバッグ用Vibeデータ表示
 ├── Managers/
@@ -188,7 +188,9 @@ ios_watchme_v9/
 ├── Models/
 │   ├── RecordingModel.swift       # 録音データモデル
 │   ├── DailyVibeReport.swift      # Vibeレポートモデル
-│   └── DeviceModel.swift          # デバイスモデル
+│   ├── DeviceModel.swift          # デバイスモデル
+│   ├── BehaviorReport.swift       # 行動レポートモデル
+│   └── EmotionReport.swift        # 感情レポートモデル
 ├── Utilities/
 │   ├── SlotTimeUtility.swift      # 時刻スロット管理
 │   └── ConnectionStatus.swift     # 接続状態管理
@@ -538,6 +540,32 @@ git push origin feature/機能名
 ```
 
 ## 更新履歴
+
+### 2025年7月27日
+- **v9.10.0 - 行動グラフと感情グラフの実装**
+  - **行動グラフ (Behavior Graph) の実装**
+    - behavior_summaryテーブルからのデータ取得機能
+    - 1日の行動ランキング表示（上位5件）
+    - 48個の時間ブロック（30分単位）での行動可視化
+    - 時間帯別の色分け表示（深夜・朝・昼・夕方・夜）
+    - タップで各時間帯の詳細表示
+  
+  - **感情グラフ (Emotion Graph) の実装**
+    - emotion_opensmile_summaryテーブルからのデータ取得機能
+    - 8つの感情の1日の合計値をランキング表示
+    - 48時間帯の感情推移を折れ線グラフで表示
+    - Charts frameworkを使用した美しいグラフ描画
+    - 各感情の表示/非表示切り替え機能
+    - 凡例の表示/非表示機能
+  
+  - **データモデルの追加**
+    - BehaviorReport.swift: 行動データモデル
+    - EmotionReport.swift: 感情データモデル（8感情対応）
+  
+  - **SupabaseDataManagerの拡張**
+    - fetchBehaviorReport()メソッドの追加
+    - fetchEmotionReport()メソッドの追加
+    - 既存の認証・デバイス管理機能との統合
 
 ### 2025年7月25日
 - **v9.9.0 - データ管理の一元化リファクタリング**

--- a/ios_watchme_v9/BehaviorGraphView.swift
+++ b/ios_watchme_v9/BehaviorGraphView.swift
@@ -8,32 +8,328 @@
 import SwiftUI
 
 struct BehaviorGraphView: View {
+    @EnvironmentObject var authManager: SupabaseAuthManager
+    @EnvironmentObject var deviceManager: DeviceManager
+    @EnvironmentObject var dataManager: SupabaseDataManager
+    
+    @State private var selectedDate = Date()
+    @State private var behaviorReport: BehaviorReport?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var showingError = false
+    @State private var expandedTimeBlocks: Set<String> = []
+    
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.locale = Locale(identifier: "ja_JP")
+        return formatter
+    }()
+    
     var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
+        VStack(spacing: 0) {
+            // Date Navigation
+            HStack(spacing: 20) {
+                Button(action: { changeDate(by: -1) }) {
+                    Image(systemName: "chevron.left.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+                }
+                
+                Text(dateFormatter.string(from: selectedDate))
+                    .font(.headline)
+                    .frame(minWidth: 150)
+                
+                Button(action: { changeDate(by: 1) }) {
+                    Image(systemName: "chevron.right.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+                }
+            }
+            .padding(.vertical, 12)
+            .background(Color(.systemBackground))
+            .overlay(
+                Rectangle()
+                    .frame(height: 0.5)
+                    .foregroundColor(Color(.separator)),
+                alignment: .bottom
+            )
             
-            Image(systemName: "figure.walk.motion")
-                .font(.system(size: 80))
-                .foregroundColor(.blue.opacity(0.5))
-            
-            Text("行動グラフ")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-            
-            Text("Coming Soon")
-                .font(.title2)
-                .foregroundColor(.secondary)
-            
-            Text("行動パターンの分析機能を準備中です")
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 40)
-            
-            Spacer()
+            ScrollView {
+                VStack(spacing: 16) {
+                    if isLoading {
+                        ProgressView("データを読み込み中...")
+                            .padding(.top, 50)
+                    } else if let report = behaviorReport {
+                        // Summary Ranking Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Image(systemName: "chart.bar.fill")
+                                    .foregroundColor(.blue)
+                                Text("1日の行動ランキング")
+                                    .font(.headline)
+                                Spacer()
+                                Text("合計: \(report.totalEventCount)件")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.horizontal)
+                            
+                            ForEach(Array(report.summaryRanking.prefix(5).enumerated()), id: \.offset) { index, event in
+                                HStack {
+                                    Text("\(index + 1).")
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(.secondary)
+                                        .frame(width: 25, alignment: .trailing)
+                                    
+                                    Text(event.event)
+                                        .font(.subheadline)
+                                    
+                                    Spacer()
+                                    
+                                    Text("\(event.count)回")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal)
+                                .padding(.vertical, 4)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(Color(.systemGray6))
+                                )
+                                .padding(.horizontal)
+                            }
+                        }
+                        .padding(.vertical, 12)
+                        
+                        Divider()
+                            .padding(.horizontal)
+                        
+                        // Time Blocks Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Image(systemName: "clock.fill")
+                                    .foregroundColor(.blue)
+                                Text("時間帯別の行動")
+                                    .font(.headline)
+                                Spacer()
+                                Text("\(report.activeTimeBlocks.count)/48 スロット")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.horizontal)
+                            
+                            // Time blocks grid
+                            LazyVGrid(columns: [
+                                GridItem(.flexible()),
+                                GridItem(.flexible()),
+                                GridItem(.flexible()),
+                                GridItem(.flexible())
+                            ], spacing: 8) {
+                                ForEach(report.sortedTimeBlocks, id: \.time) { block in
+                                    TimeBlockCell(
+                                        timeBlock: block,
+                                        isExpanded: expandedTimeBlocks.contains(block.time)
+                                    ) {
+                                        toggleTimeBlock(block.time)
+                                    }
+                                }
+                            }
+                            .padding(.horizontal)
+                        }
+                        .padding(.vertical, 12)
+                        
+                    } else {
+                        VStack(spacing: 20) {
+                            Image(systemName: "chart.bar.doc.horizontal")
+                                .font(.system(size: 60))
+                                .foregroundColor(.gray.opacity(0.5))
+                            
+                            Text("この日のデータがありません")
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.top, 50)
+                    }
+                }
+                .padding(.bottom, 20)
+            }
         }
         .navigationTitle("行動グラフ")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            fetchBehaviorData()
+        }
+        .alert("エラー", isPresented: $showingError) {
+            Button("OK") { }
+        } message: {
+            Text(errorMessage ?? "不明なエラーが発生しました")
+        }
+    }
+    
+    private func fetchBehaviorData() {
+        guard authManager.isAuthenticated else {
+            errorMessage = "ログインが必要です"
+            showingError = true
+            return
+        }
+        
+        guard let deviceId = deviceManager.selectedDeviceID ?? deviceManager.actualDeviceID else {
+            errorMessage = "デバイスが登録されていません"
+            showingError = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        Task {
+            do {
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd"
+                let dateString = formatter.string(from: selectedDate)
+                
+                let report = try await dataManager.fetchBehaviorReport(
+                    deviceId: deviceId,
+                    date: dateString
+                )
+                
+                await MainActor.run {
+                    self.behaviorReport = report
+                    self.isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                    self.showingError = true
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+    
+    private func changeDate(by days: Int) {
+        if let newDate = Calendar.current.date(byAdding: .day, value: days, to: selectedDate) {
+            selectedDate = newDate
+            expandedTimeBlocks.removeAll()
+            fetchBehaviorData()
+        }
+    }
+    
+    private func toggleTimeBlock(_ time: String) {
+        if expandedTimeBlocks.contains(time) {
+            expandedTimeBlocks.remove(time)
+        } else {
+            expandedTimeBlocks.insert(time)
+        }
+    }
+}
+
+// MARK: - Time Block Cell
+struct TimeBlockCell: View {
+    let timeBlock: TimeBlock
+    let isExpanded: Bool
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 4) {
+                Text(timeBlock.displayTime)
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .foregroundColor(timeBlock.isEmpty ? .secondary : .primary)
+                
+                if timeBlock.isEmpty {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(.systemGray5))
+                        .frame(height: 20)
+                        .overlay(
+                            Text("-")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        )
+                } else {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(backgroundGradient(for: timeBlock.hourInt))
+                        .frame(height: 20)
+                        .overlay(
+                            Text("\(timeBlock.events?.count ?? 0)")
+                                .font(.caption2)
+                                .fontWeight(.medium)
+                                .foregroundColor(.white)
+                        )
+                }
+            }
+        }
+        .buttonStyle(PlainButtonStyle())
+        .sheet(isPresented: .constant(isExpanded && !timeBlock.isEmpty)) {
+            TimeBlockDetailView(timeBlock: timeBlock, onDismiss: onTap)
+                .presentationDetents([.medium])
+        }
+    }
+    
+    private func backgroundGradient(for hour: Int) -> LinearGradient {
+        let colors: [Color]
+        switch hour {
+        case 0..<6:
+            colors = [.purple, .indigo] // 深夜
+        case 6..<9:
+            colors = [.orange, .yellow] // 朝
+        case 9..<12:
+            colors = [.blue, .cyan] // 午前
+        case 12..<15:
+            colors = [.green, .mint] // 午後早め
+        case 15..<18:
+            colors = [.teal, .blue] // 午後
+        case 18..<21:
+            colors = [.orange, .red] // 夕方
+        default:
+            colors = [.indigo, .purple] // 夜
+        }
+        
+        return LinearGradient(
+            gradient: Gradient(colors: colors),
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
+// MARK: - Time Block Detail View
+struct TimeBlockDetailView: View {
+    let timeBlock: TimeBlock
+    let onDismiss: () -> Void
+    
+    var body: some View {
+        NavigationView {
+            List {
+                Section(header: Text("\(timeBlock.displayTime) の行動")) {
+                    if let events = timeBlock.events {
+                        ForEach(events) { event in
+                            HStack {
+                                Text(event.event)
+                                    .font(.subheadline)
+                                Spacer()
+                                Text("\(event.count)回")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("時間帯詳細")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("閉じる") {
+                        onDismiss()
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/ios_watchme_v9/EmotionGraphView.swift
+++ b/ios_watchme_v9/EmotionGraphView.swift
@@ -6,34 +6,308 @@
 //
 
 import SwiftUI
+import Charts
 
 struct EmotionGraphView: View {
+    @EnvironmentObject var authManager: SupabaseAuthManager
+    @EnvironmentObject var deviceManager: DeviceManager
+    @EnvironmentObject var dataManager: SupabaseDataManager
+    
+    @State private var selectedDate = Date()
+    @State private var emotionReport: EmotionReport?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var showingError = false
+    @State private var selectedEmotions: Set<EmotionType> = Set(EmotionType.allCases)
+    @State private var showingLegend = true
+    
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.locale = Locale(identifier: "ja_JP")
+        return formatter
+    }()
+    
     var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
+        VStack(spacing: 0) {
+            // Date Navigation
+            HStack(spacing: 20) {
+                Button(action: { changeDate(by: -1) }) {
+                    Image(systemName: "chevron.left.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+                }
+                
+                Text(dateFormatter.string(from: selectedDate))
+                    .font(.headline)
+                    .frame(minWidth: 150)
+                
+                Button(action: { changeDate(by: 1) }) {
+                    Image(systemName: "chevron.right.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+                }
+            }
+            .padding(.vertical, 12)
+            .background(Color(.systemBackground))
+            .overlay(
+                Rectangle()
+                    .frame(height: 0.5)
+                    .foregroundColor(Color(.separator)),
+                alignment: .bottom
+            )
             
-            Image(systemName: "heart.text.square")
-                .font(.system(size: 80))
-                .foregroundColor(.pink.opacity(0.5))
-            
-            Text("感情グラフ")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-            
-            Text("Coming Soon")
-                .font(.title2)
-                .foregroundColor(.secondary)
-            
-            Text("感情の変化を詳細に分析する機能を準備中です")
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 40)
-            
-            Spacer()
+            ScrollView {
+                VStack(spacing: 16) {
+                    if isLoading {
+                        ProgressView("データを読み込み中...")
+                            .padding(.top, 50)
+                    } else if let report = emotionReport {
+                        // Emotion Ranking Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Image(systemName: "list.number")
+                                    .foregroundColor(.blue)
+                                Text("1日の感情ランキング")
+                                    .font(.headline)
+                                Spacer()
+                            }
+                            .padding(.horizontal)
+                            
+                            ForEach(Array(report.emotionRanking.prefix(8).enumerated()), id: \.offset) { index, emotion in
+                                if emotion.value > 0 {
+                                    HStack {
+                                        Text("\(index + 1).")
+                                            .font(.subheadline)
+                                            .fontWeight(.medium)
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 25, alignment: .trailing)
+                                        
+                                        Circle()
+                                            .fill(emotion.color)
+                                            .frame(width: 12, height: 12)
+                                        
+                                        Text(emotion.name)
+                                            .font(.subheadline)
+                                        
+                                        Spacer()
+                                        
+                                        Text("\(emotion.value)")
+                                            .font(.subheadline)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    .padding(.horizontal)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .fill(Color(.systemGray6))
+                                    )
+                                    .padding(.horizontal)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 12)
+                        
+                        Divider()
+                            .padding(.horizontal)
+                        
+                        // Emotion Chart Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Image(systemName: "chart.line")
+                                    .foregroundColor(.blue)
+                                Text("時間帯別感情推移")
+                                    .font(.headline)
+                                Spacer()
+                                Button(action: { showingLegend.toggle() }) {
+                                    Image(systemName: showingLegend ? "eye.fill" : "eye.slash.fill")
+                                        .foregroundColor(.blue)
+                                }
+                            }
+                            .padding(.horizontal)
+                            
+                            // Line Chart
+                            if report.activeTimePoints.count > 0 {
+                                Chart {
+                                    ForEach(EmotionType.allCases, id: \.self) { emotionType in
+                                        if selectedEmotions.contains(emotionType) {
+                                            ForEach(report.emotionGraph, id: \.time) { point in
+                                                LineMark(
+                                                    x: .value("時間", point.timeValue),
+                                                    y: .value("値", getValue(for: emotionType, from: point))
+                                                )
+                                                .foregroundStyle(emotionType.color)
+                                                .lineStyle(StrokeStyle(lineWidth: 2))
+                                                .symbol(Circle().strokeBorder(lineWidth: 2))
+                                                .symbolSize(30)
+                                                .interpolationMethod(.catmullRom)
+                                            }
+                                        }
+                                    }
+                                }
+                                .frame(height: 300)
+                                .padding(.horizontal)
+                                .chartXScale(domain: 0...24)
+                                .chartXAxis {
+                                    AxisMarks(values: [0, 6, 12, 18, 24]) { value in
+                                        AxisGridLine()
+                                        AxisTick()
+                                        AxisValueLabel {
+                                            if let hour = value.as(Double.self) {
+                                                Text("\(Int(hour)):00")
+                                            }
+                                        }
+                                    }
+                                }
+                                .chartYScale(domain: 0...10)
+                                .chartYAxis {
+                                    AxisMarks(position: .leading)
+                                }
+                                
+                                // Legend
+                                if showingLegend {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("感情の種類")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                            .padding(.horizontal)
+                                        
+                                        LazyVGrid(columns: [
+                                            GridItem(.flexible()),
+                                            GridItem(.flexible())
+                                        ], spacing: 8) {
+                                            ForEach(EmotionType.allCases, id: \.self) { emotionType in
+                                                Button(action: {
+                                                    toggleEmotion(emotionType)
+                                                }) {
+                                                    HStack(spacing: 6) {
+                                                        Circle()
+                                                            .fill(emotionType.color)
+                                                            .frame(width: 10, height: 10)
+                                                        Text(emotionType.rawValue)
+                                                            .font(.caption)
+                                                            .foregroundColor(selectedEmotions.contains(emotionType) ? .primary : .secondary)
+                                                        Spacer()
+                                                    }
+                                                    .padding(.horizontal, 12)
+                                                    .padding(.vertical, 6)
+                                                    .background(
+                                                        RoundedRectangle(cornerRadius: 6)
+                                                            .fill(selectedEmotions.contains(emotionType) ? emotionType.lightColor : Color(.systemGray6))
+                                                    )
+                                                }
+                                                .buttonStyle(PlainButtonStyle())
+                                            }
+                                        }
+                                        .padding(.horizontal)
+                                    }
+                                    .padding(.top, 8)
+                                }
+                            } else {
+                                Text("データがありません")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .frame(height: 200)
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                        .padding(.vertical, 12)
+                        
+                    } else {
+                        VStack(spacing: 20) {
+                            Image(systemName: "chart.line.uptrend.xyaxis")
+                                .font(.system(size: 60))
+                                .foregroundColor(.gray.opacity(0.5))
+                            
+                            Text("この日のデータがありません")
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.top, 50)
+                    }
+                }
+                .padding(.bottom, 20)
+            }
         }
         .navigationTitle("感情グラフ")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            fetchEmotionData()
+        }
+        .alert("エラー", isPresented: $showingError) {
+            Button("OK") { }
+        } message: {
+            Text(errorMessage ?? "不明なエラーが発生しました")
+        }
+    }
+    
+    private func fetchEmotionData() {
+        guard authManager.isAuthenticated else {
+            errorMessage = "ログインが必要です"
+            showingError = true
+            return
+        }
+        
+        guard let deviceId = deviceManager.selectedDeviceID ?? deviceManager.actualDeviceID else {
+            errorMessage = "デバイスが登録されていません"
+            showingError = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        Task {
+            do {
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd"
+                let dateString = formatter.string(from: selectedDate)
+                
+                let report = try await dataManager.fetchEmotionReport(
+                    deviceId: deviceId,
+                    date: dateString
+                )
+                
+                await MainActor.run {
+                    self.emotionReport = report
+                    self.isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                    self.showingError = true
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+    
+    private func changeDate(by days: Int) {
+        if let newDate = Calendar.current.date(byAdding: .day, value: days, to: selectedDate) {
+            selectedDate = newDate
+            fetchEmotionData()
+        }
+    }
+    
+    private func toggleEmotion(_ emotionType: EmotionType) {
+        if selectedEmotions.contains(emotionType) {
+            selectedEmotions.remove(emotionType)
+        } else {
+            selectedEmotions.insert(emotionType)
+        }
+    }
+    
+    private func getValue(for emotionType: EmotionType, from point: EmotionTimePoint) -> Int {
+        switch emotionType {
+        case .joy: return point.joy
+        case .fear: return point.fear
+        case .anger: return point.anger
+        case .trust: return point.trust
+        case .disgust: return point.disgust
+        case .sadness: return point.sadness
+        case .surprise: return point.surprise
+        case .anticipation: return point.anticipation
+        }
     }
 }
 

--- a/ios_watchme_v9/Models/BehaviorReport.swift
+++ b/ios_watchme_v9/Models/BehaviorReport.swift
@@ -1,0 +1,97 @@
+//
+//  BehaviorReport.swift
+//  ios_watchme_v9
+//
+//  Created by Claude Code on 2025/07/26.
+//
+
+import Foundation
+
+// MARK: - Behavior Event Model
+struct BehaviorEvent: Codable, Identifiable {
+    let count: Int
+    let event: String
+    
+    var id: String {
+        "\(event)_\(count)"
+    }
+}
+
+// MARK: - Time Block Model
+struct TimeBlock: Codable {
+    let time: String
+    let events: [BehaviorEvent]?
+    
+    var isEmpty: Bool {
+        events == nil || events?.isEmpty == true
+    }
+    
+    var displayTime: String {
+        // "00-00" -> "00:00"
+        time.replacingOccurrences(of: "-", with: ":")
+    }
+    
+    var hourInt: Int {
+        Int(time.prefix(2)) ?? 0
+    }
+    
+    var minuteInt: Int {
+        Int(time.suffix(2)) ?? 0
+    }
+}
+
+// MARK: - Behavior Report Model
+struct BehaviorReport: Codable {
+    let deviceId: String
+    let date: String
+    let summaryRanking: [BehaviorEvent]
+    let timeBlocks: [String: [BehaviorEvent]?]
+    
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "device_id"
+        case date
+        case summaryRanking = "summary_ranking"
+        case timeBlocks = "time_blocks"
+    }
+    
+    // Helper method to get sorted time blocks
+    var sortedTimeBlocks: [TimeBlock] {
+        let allTimeSlots = generateAllTimeSlots()
+        return allTimeSlots.map { slot in
+            TimeBlock(time: slot, events: timeBlocks[slot] ?? nil)
+        }
+    }
+    
+    // Generate all 48 time slots for the day
+    private func generateAllTimeSlots() -> [String] {
+        var slots: [String] = []
+        for hour in 0..<24 {
+            for minute in [0, 30] {
+                let slot = String(format: "%02d-%02d", hour, minute)
+                slots.append(slot)
+            }
+        }
+        return slots
+    }
+    
+    // Get time blocks with data (non-empty)
+    var activeTimeBlocks: [TimeBlock] {
+        sortedTimeBlocks.filter { !$0.isEmpty }
+    }
+    
+    // Get total event count for the day
+    var totalEventCount: Int {
+        summaryRanking.reduce(0) { $0 + $1.count }
+    }
+    
+    // Format date for display
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        if let dateObj = formatter.date(from: date) {
+            formatter.dateFormat = "MMMM d, yyyy"
+            return formatter.string(from: dateObj)
+        }
+        return date
+    }
+}

--- a/ios_watchme_v9/Models/EmotionReport.swift
+++ b/ios_watchme_v9/Models/EmotionReport.swift
@@ -1,0 +1,166 @@
+//
+//  EmotionReport.swift
+//  ios_watchme_v9
+//
+//  Created by Claude Code on 2025/07/27.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Emotion Time Point Model
+struct EmotionTimePoint: Codable {
+    let time: String
+    let joy: Int
+    let fear: Int
+    let anger: Int
+    let trust: Int
+    let disgust: Int
+    let sadness: Int
+    let surprise: Int
+    let anticipation: Int
+    
+    // 時刻を表示用にフォーマット
+    var displayTime: String {
+        time // "00:00" format already
+    }
+    
+    // 時刻を数値に変換（グラフ描画用）
+    var timeValue: Double {
+        let components = time.split(separator: ":")
+        guard components.count == 2,
+              let hour = Double(components[0]),
+              let minute = Double(components[1]) else {
+            return 0
+        }
+        return hour + (minute / 60.0)
+    }
+    
+    // 全感情の合計値
+    var totalEmotions: Int {
+        joy + fear + anger + trust + disgust + sadness + surprise + anticipation
+    }
+    
+    // 最も強い感情を取得
+    var dominantEmotion: (name: String, value: Int)? {
+        let emotions = [
+            ("Joy", joy),
+            ("Fear", fear),
+            ("Anger", anger),
+            ("Trust", trust),
+            ("Disgust", disgust),
+            ("Sadness", sadness),
+            ("Surprise", surprise),
+            ("Anticipation", anticipation)
+        ]
+        return emotions.max(by: { $0.1 < $1.1 })
+    }
+}
+
+// MARK: - Emotion Report Model
+struct EmotionReport: Codable {
+    let deviceId: String
+    let date: String
+    let emotionGraph: [EmotionTimePoint]
+    let filePath: String?
+    let createdAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "device_id"
+        case date
+        case emotionGraph = "emotion_graph"
+        case filePath = "file_path"
+        case createdAt = "created_at"
+    }
+    
+    // 日付をフォーマット表示
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        if let dateObj = formatter.date(from: date) {
+            formatter.dateFormat = "MMMM d, yyyy"
+            formatter.locale = Locale(identifier: "ja_JP")
+            return formatter.string(from: dateObj)
+        }
+        return date
+    }
+    
+    // 感情ごとの1日の合計値を計算
+    var emotionTotals: EmotionTotals {
+        var totals = EmotionTotals()
+        for point in emotionGraph {
+            totals.joy += point.joy
+            totals.fear += point.fear
+            totals.anger += point.anger
+            totals.trust += point.trust
+            totals.disgust += point.disgust
+            totals.sadness += point.sadness
+            totals.surprise += point.surprise
+            totals.anticipation += point.anticipation
+        }
+        return totals
+    }
+    
+    // ランキング形式で感情を取得
+    var emotionRanking: [(name: String, value: Int, color: Color)] {
+        let totals = emotionTotals
+        let emotions: [(String, Int, Color)] = [
+            ("Joy", totals.joy, .yellow),
+            ("Trust", totals.trust, .green),
+            ("Anticipation", totals.anticipation, .orange),
+            ("Surprise", totals.surprise, .cyan),
+            ("Fear", totals.fear, .purple),
+            ("Sadness", totals.sadness, .blue),
+            ("Disgust", totals.disgust, .brown),
+            ("Anger", totals.anger, .red)
+        ]
+        return emotions.sorted(by: { $0.1 > $1.1 })
+    }
+    
+    // データがある時間帯のみ取得
+    var activeTimePoints: [EmotionTimePoint] {
+        emotionGraph.filter { $0.totalEmotions > 0 }
+    }
+}
+
+// MARK: - Emotion Totals
+struct EmotionTotals {
+    var joy: Int = 0
+    var fear: Int = 0
+    var anger: Int = 0
+    var trust: Int = 0
+    var disgust: Int = 0
+    var sadness: Int = 0
+    var surprise: Int = 0
+    var anticipation: Int = 0
+}
+
+// MARK: - Emotion Type Enum
+enum EmotionType: String, CaseIterable {
+    case joy = "Joy"
+    case fear = "Fear"
+    case anger = "Anger"
+    case trust = "Trust"
+    case disgust = "Disgust"
+    case sadness = "Sadness"
+    case surprise = "Surprise"
+    case anticipation = "Anticipation"
+    
+    var color: Color {
+        switch self {
+        case .joy: return .yellow
+        case .fear: return .purple
+        case .anger: return .red
+        case .trust: return .green
+        case .disgust: return .brown
+        case .sadness: return .blue
+        case .surprise: return .cyan
+        case .anticipation: return .orange
+        }
+    }
+    
+    // グラフ表示用の薄い色
+    var lightColor: Color {
+        color.opacity(0.3)
+    }
+}

--- a/ios_watchme_v9/SupabaseDataManager.swift
+++ b/ios_watchme_v9/SupabaseDataManager.swift
@@ -287,4 +287,134 @@ class SupabaseDataManager: ObservableObject {
         weeklyReports = []
         errorMessage = nil
     }
+    
+    // MARK: - Behavior Report Methods
+    
+    /// 特定の日付の行動レポートを取得
+    func fetchBehaviorReport(deviceId: String, date: String) async throws -> BehaviorReport? {
+        print("📊 Fetching behavior report for device: \(deviceId), date: \(date)")
+        
+        // URLの構築
+        guard let url = URL(string: "\(supabaseURL)/rest/v1/behavior_summary") else {
+            throw URLError(.badURL)
+        }
+        
+        // クエリパラメータの構築
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "device_id", value: "eq.\(deviceId)"),
+            URLQueryItem(name: "date", value: "eq.\(date)"),
+            URLQueryItem(name: "select", value: "*")
+        ]
+        
+        guard let requestURL = components?.url else {
+            throw URLError(.badURL)
+        }
+        
+        // リクエストの構築
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(supabaseAnonKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(supabaseAnonKey, forHTTPHeaderField: "apikey")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        
+        print("📡 Behavior response status: \(httpResponse.statusCode)")
+        
+        if httpResponse.statusCode == 200 {
+            // レスポンスの生データを確認
+            if let rawResponse = String(data: data, encoding: .utf8) {
+                print("📄 Raw behavior response: \(rawResponse)")
+            }
+            
+            // レスポンスをデコード
+            let decoder = JSONDecoder()
+            let reports = try decoder.decode([BehaviorReport].self, from: data)
+            
+            if let report = reports.first {
+                print("✅ Behavior report fetched successfully")
+                print("   Total events: \(report.totalEventCount)")
+                print("   Active time blocks: \(report.activeTimeBlocks.count)")
+                return report
+            } else {
+                print("⚠️ No behavior report found for the specified date")
+                return nil
+            }
+        } else {
+            if let errorData = String(data: data, encoding: .utf8) {
+                print("❌ Error response: \(errorData)")
+            }
+            throw URLError(.badServerResponse)
+        }
+    }
+    
+    // MARK: - Emotion Report Methods
+    
+    /// 特定の日付の感情レポートを取得
+    func fetchEmotionReport(deviceId: String, date: String) async throws -> EmotionReport? {
+        print("🎭 Fetching emotion report for device: \(deviceId), date: \(date)")
+        
+        // URLの構築
+        guard let url = URL(string: "\(supabaseURL)/rest/v1/emotion_opensmile_summary") else {
+            throw URLError(.badURL)
+        }
+        
+        // クエリパラメータの構築
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "device_id", value: "eq.\(deviceId)"),
+            URLQueryItem(name: "date", value: "eq.\(date)"),
+            URLQueryItem(name: "select", value: "*")
+        ]
+        
+        guard let requestURL = components?.url else {
+            throw URLError(.badURL)
+        }
+        
+        // リクエストの構築
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(supabaseAnonKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(supabaseAnonKey, forHTTPHeaderField: "apikey")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        
+        print("📡 Emotion response status: \(httpResponse.statusCode)")
+        
+        if httpResponse.statusCode == 200 {
+            // レスポンスの生データを確認
+            if let rawResponse = String(data: data, encoding: .utf8) {
+                print("📄 Raw emotion response: \(rawResponse)")
+            }
+            
+            // レスポンスをデコード
+            let decoder = JSONDecoder()
+            let reports = try decoder.decode([EmotionReport].self, from: data)
+            
+            if let report = reports.first {
+                print("✅ Emotion report fetched successfully")
+                print("   Emotion graph points: \(report.emotionGraph.count)")
+                print("   Active time points: \(report.activeTimePoints.count)")
+                return report
+            } else {
+                print("⚠️ No emotion report found for the specified date")
+                return nil
+            }
+        } else {
+            if let errorData = String(data: data, encoding: .utf8) {
+                print("❌ Error response: \(errorData)")
+            }
+            throw URLError(.badServerResponse)
+        }
+    }
 }


### PR DESCRIPTION
- 行動グラフ (BehaviorGraphView) の実装
  - behavior_summaryテーブルからのデータ取得
  - 1日の行動ランキング表示
  - 48個の時間ブロックでの行動可視化
  - 時間帯別色分け表示とタップ詳細表示

- 感情グラフ (EmotionGraphView) の実装
  - emotion_opensmile_summaryテーブルからのデータ取得
  - 8つの感情のランキング表示
  - Charts frameworkを使用した折れ線グラフ
  - 感情の表示/非表示切り替え機能

- データモデルの追加
  - BehaviorReport.swift: 行動データモデル
  - EmotionReport.swift: 感情データモデル

- SupabaseDataManagerの拡張
  - fetchBehaviorReport()メソッドの追加
  - fetchEmotionReport()メソッドの追加

- アーキテクチャの改善
  - 全グラフビューでSupabaseDataManagerを@EnvironmentObjectとして統一
  - Single Source of Truthの完全実現

🤖 Generated with [Claude Code](https://claude.ai/code)